### PR TITLE
Update level config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Plays a WarriorJS level using the player's code.
   * `floor` *(Object)*: The floor of the level, with the following members:
     * `size` *(Object)*: The size of the floor.
     * `stairs` *(Object)*: The position of the stairs.
-    * `warrior` *(Object)*: The player's warrior.
-    * `units` *(Array)*: The other units in the level.
-2. `playerCode` *(String)*: The code written by the player.
-3. `[maxTurns]` *(Number)*: The maximum number of turns that will be played.
+    * `units` *(Array)*: The units in the level.
+2. `warriorName` *(String)*: The name of the warrior.
+3. `playerCode` *(String)*: The code written by the player.
+4. `[maxTurns]` *(Number)*: The maximum number of turns that will be played.
 
 #### Returns
 
@@ -50,42 +50,48 @@ const levelConfig = {
   floor: {
     size: {
       width: 8,
-      height: 1
+      height: 1,
     },
     stairs: {
       x: 7,
-      y: 0
-    },
-    warrior: {
-      name: 'Spartacus',
-      x: 0,
       y: 0,
-      facing: 'east',
-      abilities: [
-        {
-          name: 'walk',
-          args: []
-        },
-        {
-          name: 'attack',
-          args: []
-        },
-        {
-          name: 'feel',
-          args: []
-        }
-      ]
     },
     units: [
       {
+        type: 'warrior',
+        position: {
+          x: 0,
+          y: 0,
+          direction: 'east',
+        },
+        abilities: [
+          {
+            name: 'walk',
+            args: [],
+          },
+          {
+            name: 'attack',
+            args: [],
+          },
+          {
+            name: 'feel',
+            args: [],
+          },
+        ],
+      },
+      {
         type: 'sludge',
-        x: 4,
-        y: 0,
-        facing: 'west'
-      }
-    ]
-  }
+        position: {
+          x: 4,
+          y: 0,
+          direction: 'west',
+        },
+      },
+    ],
+  },
 };
+
+const warriorName = 'Spartacus';
 
 const playerCode = `
   class Player {
@@ -99,5 +105,5 @@ const playerCode = `
   }
 `;
 
-const { passed, score, events } = playLevel(levelConfig, playerCode);
+const { passed, score, events } = playLevel(levelConfig, warriorName, playerCode);
 ```

--- a/src/Floor.js
+++ b/src/Floor.js
@@ -85,7 +85,7 @@ export default class Floor {
     this._stairsLocation = [x, y];
   }
 
-  addUnit(unit, x, y, direction) {
+  addUnit(unit, { x, y, direction }) {
     const positionedUnit = unit;
     positionedUnit.position = new Position(this, x, y, direction);
     this._units.push(positionedUnit);

--- a/src/LevelLoader.js
+++ b/src/LevelLoader.js
@@ -57,17 +57,20 @@ export default class LevelLoader {
     this._level = level;
   }
 
-  load(levelConfig) {
+  load(levelConfig, warriorName) {
     this._level.timeBonus = levelConfig.timeBonus;
 
-    const { size, stairs, warrior, units } = levelConfig.floor;
+    const { size, stairs, units } = levelConfig.floor;
 
     this._setFloor(size, stairs);
 
-    const { name, x, y, facing, abilities } = warrior;
-    this._placeWarrior(name, x, y, facing, abilities);
-
-    units.forEach(unit => this._placeUnit(unit.type, unit.x, unit.y, unit.facing, unit.abilities));
+    units.forEach((unit) => {
+      const placedUnit = this._placeUnit(unit.type, unit.x, unit.y, unit.facing, unit.abilities);
+      if (unit.type === 'warrior') {
+        placedUnit.name = warriorName;
+        this._level.warrior = placedUnit;
+      }
+    });
   }
 
   _setFloor(size, stairs) {
@@ -76,12 +79,6 @@ export default class LevelLoader {
 
     const { x, y } = stairs;
     this._level.floor.placeStairs(x, y);
-  }
-
-  _placeWarrior(name, x, y, facing, abilities) {
-    const warrior = this._placeUnit('warrior', x, y, facing, abilities);
-    warrior.name = name;
-    this._level.warrior = warrior;
   }
 
   _placeUnit(type, x, y, facing, abilities = []) {

--- a/src/LevelLoader.js
+++ b/src/LevelLoader.js
@@ -64,6 +64,10 @@ export default class LevelLoader {
 
     this._setFloor(size, stairs);
 
+    if (units.filter(unit => unit.type === 'warrior').length !== 1) {
+      throw new Error('One unit in the level must be a warrior.');
+    }
+
     units.forEach(({ type, position, abilities }) => {
       const unit = this._placeUnit(type, position, abilities);
       if (type === 'warrior') {

--- a/src/LevelLoader.js
+++ b/src/LevelLoader.js
@@ -64,11 +64,11 @@ export default class LevelLoader {
 
     this._setFloor(size, stairs);
 
-    units.forEach((unit) => {
-      const placedUnit = this._placeUnit(unit.type, unit.x, unit.y, unit.facing, unit.abilities);
-      if (unit.type === 'warrior') {
-        placedUnit.name = warriorName;
-        this._level.warrior = placedUnit;
+    units.forEach(({ type, position, abilities }) => {
+      const unit = this._placeUnit(type, position, abilities);
+      if (type === 'warrior') {
+        unit.name = warriorName;
+        this._level.warrior = unit;
       }
     });
   }
@@ -81,7 +81,7 @@ export default class LevelLoader {
     this._level.floor.placeStairs(x, y);
   }
 
-  _placeUnit(type, x, y, facing, abilities = []) {
+  _placeUnit(type, position, abilities = []) {
     if (!(type in UNITS)) {
       throw new Error(`Unknown unit '${type}'.`);
     }
@@ -96,7 +96,7 @@ export default class LevelLoader {
       unit.abilities.set(name, new ABILITIES[name](unit, ...args));
     });
 
-    this._level.floor.addUnit(unit, x, y, facing);
+    this._level.floor.addUnit(unit, position);
 
     return unit;
   }

--- a/src/playLevel.js
+++ b/src/playLevel.js
@@ -2,8 +2,8 @@ import Level from './Level';
 
 const MAX_TURNS = 1000;
 
-export default function playLevel(levelConfig, playerCode, maxTurns = MAX_TURNS) {
-  const level = Level.load(levelConfig);
+export default function playLevel(levelConfig, warriorName, playerCode, maxTurns = MAX_TURNS) {
+  const level = Level.load(levelConfig, warriorName);
   level.loadPlayer(playerCode);
   return level.play(maxTurns);
 }

--- a/test/Floor.spec.js
+++ b/test/Floor.spec.js
@@ -12,13 +12,13 @@ describe('Floor', () => {
 
   it('should be able to add a unit and fetch it at that position', () => {
     const unit = new Unit();
-    floor.addUnit(unit, 0, 1, 'north');
+    floor.addUnit(unit, { x: 0, y: 1 });
     expect(floor.getUnitAt(0, 1)).toBe(unit);
   });
 
   it('should not consider unit on floor if no position', () => {
     const unit = new Unit();
-    floor.addUnit(unit, 0, 1, 'north');
+    floor.addUnit(unit, { x: 0, y: 1 });
     unit.position = null;
     expect(floor.units).not.toContain(unit);
   });
@@ -26,16 +26,16 @@ describe('Floor', () => {
   it('should fetch other units not warrior', () => {
     const unit = new Unit();
     const warrior = new Warrior();
-    floor.addUnit(unit, 0, 0, 'north');
-    floor.addUnit(warrior, 1, 0, 'north');
+    floor.addUnit(unit, { x: 0, y: 0 });
+    floor.addUnit(warrior, { x: 1, y: 0 });
     expect(floor.otherUnits).toContain(unit);
     expect(floor.otherUnits).not.toContain(warrior);
   });
 
   it('should return unique units', () => {
     const unit = new Unit();
-    floor.addUnit(unit, 0, 0);
-    floor.addUnit(new Unit(), 1, 0);
+    floor.addUnit(unit, { x: 0, y: 0 });
+    floor.addUnit(new Unit(), { x: 1, y: 0 });
     expect(floor.uniqueUnits).toEqual([unit]);
   });
 

--- a/test/Level.spec.js
+++ b/test/Level.spec.js
@@ -21,7 +21,7 @@ describe('Level', () => {
 
   it('should consider passed when warrior is on stairs', () => {
     level.warrior = new Warrior();
-    floor.addUnit(level.warrior, 0, 0, 'north');
+    floor.addUnit(level.warrior, { x: 0, y: 0, direction: 'north' });
     floor.placeStairs(0, 0);
     expect(level._passed()).toBe(true);
   });
@@ -31,7 +31,7 @@ describe('Level', () => {
       const unit = new Unit();
       unit.prepareTurn = jest.fn();
       unit.performTurn = jest.fn();
-      floor.addUnit(unit, 0, 0, 'north');
+      floor.addUnit(unit, { x: 0, y: 0, direction: 'north' });
       level.play(2);
       expect(unit.prepareTurn.mock.calls.length).toBe(2);
       expect(unit.performTurn.mock.calls.length).toBe(2);
@@ -40,7 +40,7 @@ describe('Level', () => {
     it('should return immediately when passed', () => {
       const unit = new Unit();
       unit.performTurn = jest.fn();
-      floor.addUnit(unit, 0, 0, 'north');
+      floor.addUnit(unit, { x: 0, y: 0, direction: 'north' });
       level._passed = jest.fn().mockReturnValue(true);
       level.play(2);
       expect(unit.performTurn.mock.calls.length).toBe(0);

--- a/test/Position.spec.js
+++ b/test/Position.spec.js
@@ -9,7 +9,7 @@ describe('Position', () => {
   beforeEach(() => {
     unit = new Unit();
     floor = new Floor(6, 5);
-    floor.addUnit(unit, 1, 2, 'north');
+    floor.addUnit(unit, { x: 1, y: 2, direction: 'north' });
     position = unit.position;
   });
 
@@ -34,23 +34,23 @@ describe('Position', () => {
   });
 
   it('should get relative space in front', () => {
-    floor.addUnit(new Unit(), 1, 1);
+    floor.addUnit(new Unit(), { x: 1, y: 1 });
     expect(position.getRelativeSpace(1).isEmpty()).toBe(false);
   });
 
   it('should get relative object in front when rotated', () => {
-    floor.addUnit(new Unit(), 2, 2);
+    floor.addUnit(new Unit(), { x: 2, y: 2 });
     position.rotate(1);
     expect(position.getRelativeSpace(1).isEmpty()).toBe(false);
   });
 
   it('should get relative object diagonally', () => {
-    floor.addUnit(new Unit(), 0, 1);
+    floor.addUnit(new Unit(), { x: 0, y: 1 });
     expect(position.getRelativeSpace(1, -1).isEmpty()).toBe(false);
   });
 
   it('should get relative object diagonally when rotated', () => {
-    floor.addUnit(new Unit(), 0, 1);
+    floor.addUnit(new Unit(), { x: 0, y: 1 });
     position.rotate(2);
     expect(position.getRelativeSpace(-1, 1).isEmpty()).toBe(false);
   });

--- a/test/Space.spec.js
+++ b/test/Space.spec.js
@@ -75,7 +75,7 @@ describe('Space', () => {
     let space;
 
     beforeEach(() => {
-      floor.addUnit(new Warrior(), 0, 0);
+      floor.addUnit(new Warrior(), { x: 0, y: 0 });
       space = floor.getSpaceAt(0, 0);
     });
 
@@ -104,7 +104,7 @@ describe('Space', () => {
     let space;
 
     beforeEach(() => {
-      floor.addUnit(new Sludge(), 0, 0);
+      floor.addUnit(new Sludge(), { x: 0, y: 0 });
       space = floor.getSpaceAt(0, 0);
     });
 
@@ -145,7 +145,7 @@ describe('Space', () => {
 
     beforeEach(() => {
       captive = new Captive();
-      floor.addUnit(captive, 0, 0);
+      floor.addUnit(captive, { x: 0, y: 0 });
       space = floor.getSpaceAt(0, 0);
     });
 

--- a/test/abilities/actions/Detonate.spec.js
+++ b/test/abilities/actions/Detonate.spec.js
@@ -13,7 +13,7 @@ describe('Detonate', () => {
   beforeEach(() => {
     floor = new Floor(2, 3);
     warrior = new Warrior();
-    floor.addUnit(warrior, 0, 0, 'south');
+    floor.addUnit(warrior, { x: 0, y: 0, direction: 'south' });
     detonate = new Detonate(warrior);
   });
 
@@ -22,8 +22,8 @@ describe('Detonate', () => {
     targetUnit.health = 15;
     const otherUnit = new Unit();
     otherUnit.health = 15;
-    floor.addUnit(targetUnit, 0, 1);
-    floor.addUnit(otherUnit, 1, 1);
+    floor.addUnit(targetUnit, { x: 0, y: 1 });
+    floor.addUnit(otherUnit, { x: 1, y: 1 });
     detonate.perform();
     expect(targetUnit.health).toBe(7);
     expect(otherUnit.health).toBe(11);
@@ -34,8 +34,8 @@ describe('Detonate', () => {
     targetUnit.health = 15;
     const otherUnit = new Unit();
     otherUnit.health = 15;
-    floor.addUnit(targetUnit, 1, 0);
-    floor.addUnit(otherUnit, 1, 1);
+    floor.addUnit(targetUnit, { x: 1, y: 0 });
+    floor.addUnit(otherUnit, { x: 1, y: 1 });
     detonate.perform('left');
     expect(targetUnit.health).toBe(7);
     expect(otherUnit.health).toBe(11);
@@ -45,7 +45,7 @@ describe('Detonate', () => {
     const captive = new Captive();
     captive.health = 1;
     captive.abilities.set('explode', new Explode(captive));
-    floor.addUnit(captive, 1, 1);
+    floor.addUnit(captive, { x: 1, y: 1 });
     detonate.perform();
     expect(captive.health).toBe(0);
     expect(warrior.health).toBe(0);

--- a/test/abilities/actions/Explode.spec.js
+++ b/test/abilities/actions/Explode.spec.js
@@ -13,7 +13,7 @@ describe('Explode', () => {
   beforeEach(() => {
     floor = new Floor(2, 3);
     captive = new Captive();
-    floor.addUnit(captive, 0, 0);
+    floor.addUnit(captive, { x: 0, y: 0 });
     explode = new Explode(captive, 3);
   });
 
@@ -28,7 +28,7 @@ describe('Explode', () => {
   it('should kill every unit on the floor', () => {
     const unit = new Unit();
     unit.health = 101;
-    floor.addUnit(unit, 0, 1);
+    floor.addUnit(unit, { x: 0, y: 1 });
     captive.health = 10;
     explode.perform();
     expect(captive.health).toBe(0);

--- a/test/abilities/senses/Listen.spec.js
+++ b/test/abilities/senses/Listen.spec.js
@@ -7,9 +7,9 @@ describe('Listen', () => {
   it('should return an array of spaces which have units on them besides main unit', () => {
     const floor = new Floor(2, 3);
     const warrior = new Warrior();
-    floor.addUnit(warrior, 0, 0);
+    floor.addUnit(warrior, { x: 0, y: 0 });
     const listen = new Listen(warrior);
-    floor.addUnit(new Unit(), 0, 1);
+    floor.addUnit(new Unit(), { x: 0, y: 1 });
     expect(listen.perform().length).toBe(1);
   });
 });

--- a/test/playLevel.spec.js
+++ b/test/playLevel.spec.js
@@ -1,73 +1,221 @@
 import playLevel from '../src/playLevel';
 
 describe('play level', () => {
-  const levelConfig = {
-    timeBonus: 15,
-
-    floor: {
-      size: {
-        width: 8,
-        height: 1,
-      },
-      stairs: {
-        x: 7,
-        y: 0,
-      },
-      units: [
-        {
-          type: 'warrior',
-          position: {
-            x: 0,
-            y: 0,
-            direction: 'east',
-          },
-          abilities: [
-            {
-              name: 'walk',
-              args: [],
-            },
-          ],
+  it('should throw an error when no warrior', () => {
+    const levelConfig = {
+      timeBonus: 15,
+      floor: {
+        size: {
+          width: 8,
+          height: 1,
         },
-      ],
-    },
-  };
-  const warriorName = 'Spartacus';
-
-  describe('with a winner player code', () => {
-    const playerCode = `
-      class Player {
-        playTurn(warrior) {
-          warrior.walk();
-        }
-      }
-    `;
-    const requiredTurns = 7;
-
-    it('should pass level when max turns are enough', () => {
-      const maxTurns = requiredTurns;
-      const { passed } = playLevel(levelConfig, warriorName, playerCode, maxTurns);
-      expect(passed).toBe(true);
-    });
-
-    it('should not pass level when max turns are not enough', () => {
-      const maxTurns = requiredTurns - 1;
-      const { passed } = playLevel(levelConfig, warriorName, playerCode, maxTurns);
-      expect(passed).toBe(false);
-    });
+        stairs: {
+          x: 7,
+          y: 0,
+        },
+        units: [],
+      },
+    };
+    expect(() => {
+      playLevel(levelConfig);
+    }).toThrow('One unit in the level must be a warrior.');
   });
 
-  describe('with a loser player code', () => {
-    const playerCode = `
-      class Player {
-        playTurn(warrior) {
-          // Cool code goes here
-        }
-      }
-    `;
+  it('should throw an error when more than one warrior', () => {
+    const levelConfig = {
+      timeBonus: 15,
+      floor: {
+        size: {
+          width: 8,
+          height: 1,
+        },
+        stairs: {
+          x: 7,
+          y: 0,
+        },
+        units: [
+          {
+            type: 'warrior',
+            position: {
+              x: 0,
+              y: 0,
+              direction: 'east',
+            },
+            abilities: [
+              {
+                name: 'walk',
+                args: [],
+              },
+            ],
+          },
+          {
+            type: 'warrior',
+            position: {
+              x: 0,
+              y: 1,
+              direction: 'east',
+            },
+            abilities: [
+              {
+                name: 'walk',
+                args: [],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    expect(() => {
+      playLevel(levelConfig);
+    }).toThrow('One unit in the level must be a warrior.');
+  });
 
-    it('should not pass level', () => {
-      const { passed } = playLevel(levelConfig, warriorName, playerCode);
-      expect(passed).toBe(false);
+  it('should throw an error with invalid unit', () => {
+    const levelConfig = {
+      timeBonus: 15,
+      floor: {
+        size: {
+          width: 8,
+          height: 1,
+        },
+        stairs: {
+          x: 7,
+          y: 0,
+        },
+        units: [
+          {
+            type: 'warrior',
+            position: {
+              x: 0,
+              y: 0,
+              direction: 'east',
+            },
+            abilities: [
+              {
+                name: 'walk',
+                args: [],
+              },
+            ],
+          },
+          {
+            type: 'foo',
+            position: {
+              x: 0,
+              y: 1,
+              direction: 'west',
+            },
+          },
+        ],
+      },
+    };
+    expect(() => {
+      playLevel(levelConfig);
+    }).toThrow("Unknown unit 'foo'.");
+  });
+
+  it('should throw an error with invalid ability', () => {
+    const levelConfig = {
+      timeBonus: 15,
+      floor: {
+        size: {
+          width: 8,
+          height: 1,
+        },
+        stairs: {
+          x: 7,
+          y: 0,
+        },
+        units: [
+          {
+            type: 'warrior',
+            position: {
+              x: 0,
+              y: 0,
+              direction: 'east',
+            },
+            abilities: [
+              {
+                name: 'foo',
+                args: [],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    expect(() => {
+      playLevel(levelConfig);
+    }).toThrow("Unknown ability 'foo'.");
+  });
+
+  describe('with a valid level config', () => {
+    const levelConfig = {
+      timeBonus: 15,
+      floor: {
+        size: {
+          width: 8,
+          height: 1,
+        },
+        stairs: {
+          x: 7,
+          y: 0,
+        },
+        units: [
+          {
+            type: 'warrior',
+            position: {
+              x: 0,
+              y: 0,
+              direction: 'east',
+            },
+            abilities: [
+              {
+                name: 'walk',
+                args: [],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const warriorName = 'Spartacus';
+
+    describe('with a winner player code', () => {
+      const playerCode = `
+        class Player {
+          playTurn(warrior) {
+            warrior.walk();
+          }
+        }
+      `;
+      const requiredTurns = 7;
+
+      it('should pass level when max turns are enough', () => {
+        const maxTurns = requiredTurns;
+        const { passed } = playLevel(levelConfig, warriorName, playerCode, maxTurns);
+        expect(passed).toBe(true);
+      });
+
+      it('should not pass level when max turns are not enough', () => {
+        const maxTurns = requiredTurns - 1;
+        const { passed } = playLevel(levelConfig, warriorName, playerCode, maxTurns);
+        expect(passed).toBe(false);
+      });
+    });
+
+    describe('with a loser player code', () => {
+      const playerCode = `
+        class Player {
+          playTurn(warrior) {
+            // Cool code goes here
+          }
+        }
+      `;
+
+      it('should not pass level', () => {
+        const { passed } = playLevel(levelConfig, warriorName, playerCode);
+        expect(passed).toBe(false);
+      });
     });
   });
 });

--- a/test/playLevel.spec.js
+++ b/test/playLevel.spec.js
@@ -13,21 +13,23 @@ describe('play level', () => {
         x: 7,
         y: 0,
       },
-      warrior: {
-        name: 'Spartacus',
-        x: 0,
-        y: 0,
-        facing: 'east',
-        abilities: [
-          {
-            name: 'walk',
-            args: [],
-          },
-        ],
-      },
-      units: [],
+      units: [
+        {
+          type: 'warrior',
+          x: 0,
+          y: 0,
+          facing: 'east',
+          abilities: [
+            {
+              name: 'walk',
+              args: [],
+            },
+          ],
+        },
+      ],
     },
   };
+  const warriorName = 'Spartacus';
 
   describe('with a winner player code', () => {
     const playerCode = `
@@ -41,13 +43,13 @@ describe('play level', () => {
 
     it('should pass level when max turns are enough', () => {
       const maxTurns = requiredTurns;
-      const { passed } = playLevel(levelConfig, playerCode, maxTurns);
+      const { passed } = playLevel(levelConfig, warriorName, playerCode, maxTurns);
       expect(passed).toBe(true);
     });
 
     it('should not pass level when max turns are not enough', () => {
       const maxTurns = requiredTurns - 1;
-      const { passed } = playLevel(levelConfig, playerCode, maxTurns);
+      const { passed } = playLevel(levelConfig, warriorName, playerCode, maxTurns);
       expect(passed).toBe(false);
     });
   });
@@ -62,7 +64,7 @@ describe('play level', () => {
     `;
 
     it('should not pass level', () => {
-      const { passed } = playLevel(levelConfig, playerCode);
+      const { passed } = playLevel(levelConfig, warriorName, playerCode);
       expect(passed).toBe(false);
     });
   });

--- a/test/playLevel.spec.js
+++ b/test/playLevel.spec.js
@@ -16,9 +16,11 @@ describe('play level', () => {
       units: [
         {
           type: 'warrior',
-          x: 0,
-          y: 0,
-          facing: 'east',
+          position: {
+            x: 0,
+            y: 0,
+            direction: 'east',
+          },
           abilities: [
             {
               name: 'walk',


### PR DESCRIPTION
- [x] Move `warrior` key to `units` array.
- [x] Change `playLevel` signature to receive the warrior's name.
- [x] Organize position fields under a `position` key.