### PR TITLE
Simplify logger

### DIFF
--- a/src/Level.js
+++ b/src/Level.js
@@ -1,5 +1,3 @@
-import { isEqual } from 'lodash';
-
 import LevelLoader from './LevelLoader';
 import Logger from './Logger';
 
@@ -23,32 +21,16 @@ export default class Level {
   play(turns) {
     Logger.clear();
 
-    const initialFloor = this.floor.toViewObject();
-    Logger.playStarted(initialFloor);
-
-    let lastFloor = initialFloor;
-
     // eslint-disable-next-line
     for (let n = 0; n < turns; n++) {
       if (this.passed() || this.failed()) {
         break;
       }
 
-      const turnNumber = n + 1;
-      Logger.turnChanged(turnNumber);
+      Logger.turn();
 
       this.floor.getUnits().forEach(unit => unit.prepareTurn());
-      // eslint-disable-next-line
-      this.floor.getUnits().forEach(unit => {
-        unit.performTurn();
-
-        const floor = this.floor.toViewObject();
-        if (!isEqual(lastFloor, floor)) {
-          Logger.floorChanged(floor);
-        }
-
-        lastFloor = floor;
-      });
+      this.floor.getUnits().forEach(unit => unit.performTurn());
 
       if (this.timeBonus) {
         this.timeBonus -= 1;

--- a/src/LevelLoader.js
+++ b/src/LevelLoader.js
@@ -66,8 +66,8 @@ export default class LevelLoader {
       throw new Error('One unit in the level must be a warrior.');
     }
 
-    units.forEach(({ type, position, abilities }) => {
-      const unit = this.placeUnit(type, position, abilities);
+    units.forEach(({ type, position, abilities }, index) => {
+      const unit = this.placeUnit(index, type, position, abilities);
       if (type === 'warrior') {
         unit.name = warriorName;
         this.level.warrior = unit;
@@ -83,12 +83,12 @@ export default class LevelLoader {
     this.level.floor.placeStairs(x, y);
   }
 
-  placeUnit(type, position, abilities = []) {
+  placeUnit(index, type, position, abilities = []) {
     if (!(type in UNITS)) {
       throw new Error(`Unknown unit '${type}'.`);
     }
 
-    const unit = new UNITS[type]();
+    const unit = new UNITS[type](index);
 
     abilities.forEach(({ name, args }) => {
       if (!(name in ABILITIES)) {

--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,38 +1,17 @@
-import { FLOOR_CHANGED, PLAY_STARTED, TURN_CHANGED, UNIT_SPOKE } from './constants/eventTypes';
-
-let events = [];
-
-export default class Logger {
-  static playStarted(initialFloor) {
-    events.push({
-      type: PLAY_STARTED,
-      initialFloor,
-    });
-  }
-
-  static turnChanged(turn) {
-    events.push({
-      type: TURN_CHANGED,
-      turn,
-    });
-  }
-
-  static unitSpoke(message, unitType) {
-    events.push({
-      type: UNIT_SPOKE,
+const Logger = {
+  events: [],
+  clear() {
+    Logger.events = [];
+  },
+  turn() {
+    Logger.events.push([]);
+  },
+  unit(unit, message) {
+    Logger.events[Logger.events.length - 1].push({
       message,
-      unitType,
+      unit: unit.toViewObject(),
     });
-  }
+  },
+};
 
-  static floorChanged(floor) {
-    events.push({
-      type: FLOOR_CHANGED,
-      floor,
-    });
-  }
-
-  static clear() {
-    events = [];
-  }
-}
+export default Logger;

--- a/src/Position.js
+++ b/src/Position.js
@@ -6,7 +6,21 @@ import {
   SOUTH,
   WEST,
 } from './constants/directions';
+import viewObject from './decorators/viewObject';
 
+const viewObjectShape = {
+  x() {
+    return this.x;
+  },
+  y() {
+    return this.y;
+  },
+  direction() {
+    return this.getDirection();
+  },
+};
+
+@viewObject(viewObjectShape)
 export default class Position {
   constructor(floor, x, y, direction = NORTH) {
     this.floor = floor;

--- a/src/abilities/actions/Attack.js
+++ b/src/abilities/actions/Attack.js
@@ -1,5 +1,6 @@
 import { FORWARD, BACKWARD } from '../../constants/directions';
 import Action from './Action';
+import Logger from '../../Logger';
 
 const DEFAULT_DIRECTION = FORWARD;
 
@@ -15,14 +16,15 @@ export default class Attack extends Action {
 
     const receiver = this.getUnit(direction);
     if (receiver) {
-      this.unit.say(`attacks ${direction} and hits ${receiver}`);
+      Logger.unit(this.unit, `attacks ${direction} and hits ${receiver}`);
 
       const power = direction === BACKWARD
         ? Math.ceil(this.unit.attackPower / 2.0)
         : this.unit.attackPower;
+
       this.damage(receiver, power);
     } else {
-      this.unit.say(`attacks ${direction} and hits nothing`);
+      Logger.unit(this.unit, `attacks ${direction} and hits nothing`);
     }
   }
 }

--- a/src/abilities/actions/Bind.js
+++ b/src/abilities/actions/Bind.js
@@ -1,5 +1,6 @@
 import { FORWARD } from '../../constants/directions';
 import Action from './Action';
+import Logger from '../../Logger';
 
 const DEFAULT_DIRECTION = FORWARD;
 
@@ -15,11 +16,11 @@ export default class Bind extends Action {
 
     const receiver = this.getUnit(direction);
     if (receiver) {
-      this.unit.say(`binds ${direction} and restricts ${receiver}`);
+      Logger.unit(this.unit, `binds ${direction} and restricts ${receiver}`);
 
       receiver.bind();
     } else {
-      this.unit.say(`binds ${direction} and restricts nothing`);
+      Logger.unit(this.unit, `binds ${direction} and restricts nothing`);
     }
   }
 }

--- a/src/abilities/actions/Detonate.js
+++ b/src/abilities/actions/Detonate.js
@@ -1,5 +1,6 @@
 import { FORWARD } from '../../constants/directions';
 import Action from './Action';
+import Logger from '../../Logger';
 
 const DEFAULT_DIRECTION = FORWARD;
 const TARGET_DAMAGE_AMOUNT = 8;
@@ -17,7 +18,7 @@ export default class Detonate extends Action {
     this.verifyDirection(direction);
 
     if (this.unit.isAlive()) {
-      this.unit.say(`detonates a bomb ${direction} launching a deadly explosion`);
+      Logger.unit(this.unit, `detonates a bomb ${direction} launching a deadly explosion`);
 
       const targetSpace = this.getSpace(direction, 1, 0);
       this.bomb(targetSpace, TARGET_DAMAGE_AMOUNT);
@@ -32,7 +33,7 @@ export default class Detonate extends Action {
     const receiver = space.getUnit();
     if (receiver) {
       if (receiver.abilities.has('explode')) {
-        receiver.say("caught in bomb's flames which detonates ticking explosive");
+        Logger.unit(receiver, "caught in bomb's flames which detonates ticking explosive");
 
         receiver.abilities.get('explode').perform();
       } else {

--- a/src/abilities/actions/Explode.js
+++ b/src/abilities/actions/Explode.js
@@ -1,4 +1,5 @@
 import Action from './Action';
+import Logger from '../../Logger';
 
 export default class Explode extends Action {
   constructor(unit, time) {
@@ -12,7 +13,7 @@ export default class Explode extends Action {
 
   perform() {
     if (this.unit.isAlive()) {
-      this.unit.say('explodes, collapsing the ceiling and killing every unit');
+      Logger.unit(this.unit, 'explodes, collapsing the ceiling and killing every unit');
 
       this.unit.position.floor.getUnits().forEach(unit => unit.takeDamage(Infinity));
     }
@@ -20,7 +21,7 @@ export default class Explode extends Action {
 
   passTurn() {
     if (this.time && this.unit.isAlive()) {
-      this.unit.say('is ticking');
+      Logger.unit(this.unit, 'is ticking');
 
       this.time -= 1;
       if (!this.time) {

--- a/src/abilities/actions/Pivot.js
+++ b/src/abilities/actions/Pivot.js
@@ -1,5 +1,6 @@
 import { BACKWARD, RELATIVE_DIRECTION_ARRAY } from '../../constants/directions';
 import Action from './Action';
+import Logger from '../../Logger';
 
 const DEFAULT_DIRECTION = BACKWARD;
 
@@ -13,8 +14,8 @@ export default class Pivot extends Action {
   perform(direction = DEFAULT_DIRECTION) {
     this.verifyDirection(direction);
 
-    this.unit.say(`pivots ${direction}`);
-
     this.unit.position.rotate(RELATIVE_DIRECTION_ARRAY.indexOf(direction));
+
+    Logger.unit(this.unit, `pivots ${direction}`);
   }
 }

--- a/src/abilities/actions/Rescue.js
+++ b/src/abilities/actions/Rescue.js
@@ -1,5 +1,6 @@
 import { FORWARD } from '../../constants/directions';
 import Action from './Action';
+import Logger from '../../Logger';
 
 const DEFAULT_DIRECTION = FORWARD;
 const RESCUING_BONUS = 20;
@@ -17,16 +18,18 @@ export default class Rescue extends Action {
     if (this.getSpace(direction).isCaptive()) {
       const recipient = this.getUnit(direction);
 
-      this.unit.say(`unbinds ${direction} and rescues ${recipient}`);
+      Logger.unit(this.unit, `unbinds ${direction} and rescues ${recipient}`);
 
       recipient.unbind();
       if (recipient.getType() === 'captive') {
         recipient.position = null;
 
+        Logger.unit(recipient);
+
         this.unit.earnPoints(RESCUING_BONUS);
       }
     } else {
-      this.unit.say(`unbinds ${direction} and rescues nothing`);
+      Logger.unit(this.unit, `unbinds ${direction} and rescues nothing`);
     }
   }
 }

--- a/src/abilities/actions/Rest.js
+++ b/src/abilities/actions/Rest.js
@@ -1,4 +1,5 @@
 import Action from './Action';
+import Logger from '../../Logger';
 
 const HEALTH_GAIN = 0.1;
 
@@ -18,11 +19,12 @@ export default class Rest extends Action {
 
       this.unit.health += revisedAmount;
 
-      this.unit.say(
+      Logger.unit(
+        this.unit,
         `receives ${revisedAmount} health from resting, up to ${this.unit.getHealth()} health`,
       );
     } else {
-      this.unit.say('is already fit as a fiddle');
+      Logger.unit(this.unit, 'is already fit as a fiddle');
     }
   }
 }

--- a/src/abilities/actions/Shoot.js
+++ b/src/abilities/actions/Shoot.js
@@ -2,6 +2,7 @@ import { range } from 'lodash';
 
 import { FORWARD } from '../../constants/directions';
 import Action from './Action';
+import Logger from '../../Logger';
 
 const DEFAULT_DIRECTION = FORWARD;
 const ATTACK_RANGE = 3;
@@ -22,11 +23,11 @@ export default class Shoot extends Action {
 
     const receiver = this.getUnits(direction, range(1, ATTACK_RANGE + 1))[0];
     if (receiver) {
-      this.unit.say(`shoots ${direction} and hits ${receiver}`);
+      Logger.unit(this.unit, `shoots ${direction} and hits ${receiver}`);
 
       this.damage(receiver, this.unit.shootPower);
     } else {
-      this.unit.say(`shoots ${direction} and hits nothing`);
+      Logger.unit(this.unit, `shoots ${direction} and hits nothing`);
     }
   }
 }

--- a/src/abilities/actions/Walk.js
+++ b/src/abilities/actions/Walk.js
@@ -1,5 +1,6 @@
 import { FORWARD } from '../../constants/directions';
 import Action from './Action';
+import Logger from '../../Logger';
 
 const DEFAULT_DIRECTION = FORWARD;
 
@@ -13,12 +14,12 @@ export default class Walk extends Action {
   perform(direction = DEFAULT_DIRECTION) {
     this.verifyDirection(direction);
     if (this.unit.isAlive()) {
-      this.unit.say(`walks ${direction}`);
-
       if (this.getSpace(direction).isEmpty()) {
         this.unit.position.move(...this.offset(direction));
+
+        Logger.unit(this.unit, `walks ${direction}`);
       } else {
-        this.unit.say(`bumps into ${this.getSpace(direction)}`);
+        Logger.unit(this.unit, `walks ${direction} and bumps into ${this.getSpace(direction)}`);
       }
     }
   }

--- a/src/units/Archer.js
+++ b/src/units/Archer.js
@@ -2,8 +2,8 @@ import { RELATIVE_DIRECTION_ARRAY } from '../constants/directions';
 import Ranged from './Ranged';
 
 export default class Archer extends Ranged {
-  constructor() {
-    super();
+  constructor(index) {
+    super(index);
 
     this.maxHealth = 7;
     this.shootPower = 3;

--- a/src/units/Captive.js
+++ b/src/units/Captive.js
@@ -1,8 +1,8 @@
 import Unit from './Unit';
 
 export default class Captive extends Unit {
-  constructor() {
-    super();
+  constructor(index) {
+    super(index);
 
     this.maxHealth = 1;
 

--- a/src/units/Melee.js
+++ b/src/units/Melee.js
@@ -3,8 +3,8 @@ import Feel from '../abilities/senses/Feel';
 import Unit from './Unit';
 
 export default class Melee extends Unit {
-  constructor() {
-    super();
+  constructor(index) {
+    super(index);
 
     this.abilities.set('attack', new Attack(this));
     this.abilities.set('feel', new Feel(this));

--- a/src/units/Ranged.js
+++ b/src/units/Ranged.js
@@ -3,8 +3,8 @@ import Shoot from '../abilities/actions/Shoot';
 import Unit from './Unit';
 
 export default class Ranged extends Unit {
-  constructor() {
-    super();
+  constructor(index) {
+    super(index);
 
     this.abilities.set('shoot', new Shoot(this));
     this.abilities.set('look', new Look(this));

--- a/src/units/Sludge.js
+++ b/src/units/Sludge.js
@@ -2,8 +2,8 @@ import { RELATIVE_DIRECTION_ARRAY } from '../constants/directions';
 import Melee from './Melee';
 
 export default class Sludge extends Melee {
-  constructor() {
-    super();
+  constructor(index) {
+    super(index);
 
     this.maxHealth = 12;
     this.attackPower = 3;

--- a/src/units/ThickSludge.js
+++ b/src/units/ThickSludge.js
@@ -1,8 +1,8 @@
 import Sludge from './Sludge';
 
 export default class ThickSludge extends Sludge {
-  constructor() {
-    super();
+  constructor(index) {
+    super(index);
 
     this.maxHealth = 24;
   }

--- a/src/units/Unit.js
+++ b/src/units/Unit.js
@@ -5,6 +5,9 @@ import Turn from '../Turn';
 import viewObject from '../decorators/viewObject';
 
 const viewObjectShape = {
+  index() {
+    return this.index;
+  },
   name() {
     return this.getName();
   },
@@ -21,7 +24,8 @@ const viewObjectShape = {
 
 @viewObject(viewObjectShape)
 export default class Unit {
-  constructor() {
+  constructor(index) {
+    this.index = index;
     this.position = null;
     this.maxHealth = 0;
     this.health = null;

--- a/src/units/Unit.js
+++ b/src/units/Unit.js
@@ -60,15 +60,11 @@ export default class Unit {
   unbind() {
     this.bound = false;
 
-    this.say('released from bonds');
+    Logger.unit(this, 'released from bonds');
   }
 
   bind() {
     this.bound = true;
-  }
-
-  say(message) {
-    Logger.unitSpoke(`${this.name} ${message}`, this.type);
   }
 
   takeDamage(amount) {
@@ -80,12 +76,14 @@ export default class Unit {
       const revisedAmount = this.getHealth() - amount < 0 ? this.getHealth() : amount;
       this.health -= revisedAmount;
 
-      this.say(`takes ${revisedAmount} damage, ${this.getHealth()} health power left`);
+      Logger.unit(this, `takes ${revisedAmount} damage, ${this.getHealth()} health power left`);
 
       if (!this.getHealth()) {
-        this.say('dies');
+        Logger.unit(this, 'dies');
 
         this.position = null;
+
+        Logger.unit(this);
       }
     }
   }

--- a/src/units/Unit.js
+++ b/src/units/Unit.js
@@ -6,22 +6,16 @@ import viewObject from '../decorators/viewObject';
 
 const viewObjectShape = {
   name() {
-    return this.name;
+    return this.getName();
   },
   type() {
-    return this.type;
+    return this.getType();
+  },
+  position() {
+    return this.position;
   },
   health() {
     return this.getHealth();
-  },
-  x() {
-    return this.position.x;
-  },
-  y() {
-    return this.position.y;
-  },
-  facing() {
-    return this.position.direction;
   },
 };
 

--- a/src/units/Warrior.js
+++ b/src/units/Warrior.js
@@ -1,3 +1,4 @@
+import Logger from '../Logger';
 import Unit from './Unit';
 
 export default class Warrior extends Unit {
@@ -43,7 +44,7 @@ export default class Warrior extends Unit {
 
   performTurn() {
     if (!this.currentTurn.action) {
-      this.say('does nothing');
+      Logger.unit(this, 'does nothing');
     }
 
     super.performTurn();
@@ -52,6 +53,6 @@ export default class Warrior extends Unit {
   earnPoints(points) {
     this.score += points;
 
-    this.say(`earns ${points} points`);
+    Logger.unit(this, `earns ${points} points`);
   }
 }

--- a/src/units/Warrior.js
+++ b/src/units/Warrior.js
@@ -1,8 +1,8 @@
 import Unit from './Unit';
 
 export default class Warrior extends Unit {
-  constructor() {
-    super();
+  constructor(index) {
+    super(index);
 
     this.name = null;
     this.score = 0;

--- a/src/units/Wizard.js
+++ b/src/units/Wizard.js
@@ -2,8 +2,8 @@ import { RELATIVE_DIRECTION_ARRAY } from '../constants/directions';
 import Ranged from './Ranged';
 
 export default class Wizard extends Ranged {
-  constructor() {
-    super();
+  constructor(index) {
+    super(index);
 
     this.maxHealth = 3;
     this.shootPower = 11;

--- a/test/abilities/actions/Attack.spec.js
+++ b/test/abilities/actions/Attack.spec.js
@@ -1,6 +1,10 @@
 import Attack from '../../../src/abilities/actions/Attack';
 import Unit from '../../../src/units/Unit';
 
+jest.mock('../../../src/Logger', () => ({
+  unit: () => {},
+}));
+
 describe('Attack', () => {
   let attack;
   let attacker;
@@ -9,7 +13,6 @@ describe('Attack', () => {
   beforeEach(() => {
     attacker = {
       attackPower: 3,
-      say: () => {},
     };
     attack = new Attack(attacker);
     receiver = new Unit();

--- a/test/abilities/actions/Bind.spec.js
+++ b/test/abilities/actions/Bind.spec.js
@@ -1,14 +1,16 @@
 import Bind from '../../../src/abilities/actions/Bind';
 import Unit from '../../../src/units/Unit';
 
+jest.mock('../../../src/Logger', () => ({
+  unit: () => {},
+}));
+
 describe('Bind', () => {
   let bind;
   let captor;
 
   beforeEach(() => {
-    captor = {
-      say: () => {},
-    };
+    captor = {};
     bind = new Bind(captor);
   });
 

--- a/test/abilities/actions/Detonate.spec.js
+++ b/test/abilities/actions/Detonate.spec.js
@@ -19,9 +19,9 @@ describe('Detonate', () => {
 
   it('should subtract 8 from target (forward) unit and 4 from surrounding units', () => {
     const targetUnit = new Unit();
-    targetUnit.health = 15;
+    targetUnit.maxHealth = 15;
     const otherUnit = new Unit();
-    otherUnit.health = 15;
+    otherUnit.maxHealth = 15;
     floor.addUnit(targetUnit, { x: 0, y: 1 });
     floor.addUnit(otherUnit, { x: 1, y: 1 });
     detonate.perform();
@@ -31,9 +31,9 @@ describe('Detonate', () => {
 
   it('should subtract 8 from target (left) unit and 4 from surrounding units', () => {
     const targetUnit = new Unit();
-    targetUnit.health = 15;
+    targetUnit.maxHealth = 15;
     const otherUnit = new Unit();
-    otherUnit.health = 15;
+    otherUnit.maxHealth = 15;
     floor.addUnit(targetUnit, { x: 1, y: 0 });
     floor.addUnit(otherUnit, { x: 1, y: 1 });
     detonate.perform('left');
@@ -43,7 +43,7 @@ describe('Detonate', () => {
 
   it('should detonate an explosive if any unit has one', () => {
     const captive = new Captive();
-    captive.health = 1;
+    captive.maxHealth = 1;
     captive.abilities.set('explode', new Explode(captive));
     floor.addUnit(captive, { x: 1, y: 1 });
     detonate.perform();

--- a/test/abilities/actions/Detonate.spec.js
+++ b/test/abilities/actions/Detonate.spec.js
@@ -5,6 +5,10 @@ import Floor from '../../../src/Floor';
 import Unit from '../../../src/units/Unit';
 import Warrior from '../../../src/units/Warrior';
 
+jest.mock('../../../src/Logger', () => ({
+  unit: () => {},
+}));
+
 describe('Detonate', () => {
   let detonate;
   let floor;

--- a/test/abilities/actions/Explode.spec.js
+++ b/test/abilities/actions/Explode.spec.js
@@ -18,7 +18,7 @@ describe('Explode', () => {
   });
 
   it('should explode when bomb time reaches zero', () => {
-    captive.health = 10;
+    captive.maxHealth = 10;
     times(2, () => explode.passTurn());
     expect(captive.getHealth()).toBe(10);
     explode.passTurn();
@@ -27,9 +27,9 @@ describe('Explode', () => {
 
   it('should kill every unit on the floor', () => {
     const unit = new Unit();
-    unit.health = 101;
+    unit.maxHealth = 101;
     floor.addUnit(unit, { x: 0, y: 1 });
-    captive.health = 10;
+    captive.maxHealth = 10;
     explode.perform();
     expect(captive.getHealth()).toBe(0);
     expect(unit.getHealth()).toBe(0);

--- a/test/abilities/actions/Explode.spec.js
+++ b/test/abilities/actions/Explode.spec.js
@@ -5,6 +5,10 @@ import Explode from '../../../src/abilities/actions/Explode';
 import Floor from '../../../src/Floor';
 import Unit from '../../../src/units/Unit';
 
+jest.mock('../../../src/Logger', () => ({
+  unit: () => {},
+}));
+
 describe('Explode', () => {
   let floor;
   let captive;

--- a/test/abilities/actions/Pivot.spec.js
+++ b/test/abilities/actions/Pivot.spec.js
@@ -1,5 +1,9 @@
 import Pivot from '../../../src/abilities/actions/Pivot';
 
+jest.mock('../../../src/Logger', () => ({
+  unit: () => {},
+}));
+
 describe('Pivot', () => {
   let pivot;
   let position;
@@ -10,7 +14,6 @@ describe('Pivot', () => {
     };
     pivot = new Pivot({
       position,
-      say: () => {},
     });
   });
 

--- a/test/abilities/actions/Rescue.spec.js
+++ b/test/abilities/actions/Rescue.spec.js
@@ -3,13 +3,16 @@ import Rescue from '../../../src/abilities/actions/Rescue';
 import Unit from '../../../src/units/Unit';
 import Warrior from '../../../src/units/Warrior';
 
+jest.mock('../../../src/Logger', () => ({
+  unit: () => {},
+}));
+
 describe('Rescue', () => {
   let rescue;
   let warrior;
 
   beforeEach(() => {
     warrior = new Warrior();
-    warrior.say = () => {};
     warrior.earnPoints = jest.fn();
     rescue = new Rescue(warrior);
   });
@@ -17,7 +20,6 @@ describe('Rescue', () => {
   it('should rescue captive', () => {
     const captive = new Captive();
     captive.position = {};
-    captive.say = () => {};
     rescue.getSpace = jest.fn().mockReturnValue({
       isCaptive: jest.fn().mockReturnValue(true),
     });
@@ -30,7 +32,6 @@ describe('Rescue', () => {
   it('should release other unit when bound', () => {
     const unit = new Unit();
     unit.position = {};
-    unit.say = () => {};
     unit.bind();
     rescue.getSpace = jest.fn().mockReturnValue({
       isCaptive: jest.fn().mockReturnValue(true),
@@ -45,7 +46,6 @@ describe('Rescue', () => {
   it('should do nothing to other unit if not bound', () => {
     const unit = new Unit();
     unit.position = {};
-    unit.say = () => {};
     rescue.getSpace = jest.fn().mockReturnValue({
       isCaptive: jest.fn().mockReturnValue(false),
     });

--- a/test/abilities/actions/Rest.spec.js
+++ b/test/abilities/actions/Rest.spec.js
@@ -1,13 +1,16 @@
 import Rest from '../../../src/abilities/actions/Rest';
 import Warrior from '../../../src/units/Warrior';
 
+jest.mock('../../../src/Logger', () => ({
+  unit: () => {},
+}));
+
 describe('Rest', () => {
   let rest;
   let warrior;
 
   beforeEach(() => {
     warrior = new Warrior();
-    warrior.say = () => {};
     rest = new Rest(warrior);
   });
 

--- a/test/abilities/actions/Rest.spec.js
+++ b/test/abilities/actions/Rest.spec.js
@@ -17,14 +17,13 @@ describe('Rest', () => {
     expect(warrior.getHealth()).toBe(12);
   });
 
-  it('should not add health when at max', () => {
-    warrior.health = 20;
+  it('should not go over max health', () => {
+    warrior.health = 19;
     rest.perform();
     expect(warrior.getHealth()).toBe(20);
   });
 
-  it('should not go over max health', () => {
-    warrior.health = 19;
+  it('should not add health when at max', () => {
     rest.perform();
     expect(warrior.getHealth()).toBe(20);
   });

--- a/test/abilities/actions/Shoot.spec.js
+++ b/test/abilities/actions/Shoot.spec.js
@@ -1,5 +1,9 @@
 import Shoot from '../../../src/abilities/actions/Shoot';
 
+jest.mock('../../../src/Logger', () => ({
+  unit: () => {},
+}));
+
 describe('Shoot', () => {
   let shoot;
   let shooter;
@@ -7,7 +11,6 @@ describe('Shoot', () => {
   beforeEach(() => {
     shooter = {
       shootPower: 2,
-      say: () => {},
     };
     shoot = new Shoot(shooter);
   });

--- a/test/abilities/actions/Walk.spec.js
+++ b/test/abilities/actions/Walk.spec.js
@@ -1,5 +1,9 @@
 import Walk from '../../../src/abilities/actions/Walk';
 
+jest.mock('../../../src/Logger', () => ({
+  unit: () => {},
+}));
+
 describe('Walk', () => {
   let walk;
   let space;
@@ -15,7 +19,6 @@ describe('Walk', () => {
         move: jest.fn(),
       },
       isAlive: () => true,
-      say: () => {},
     };
     walk = new Walk(unit);
   });

--- a/test/abilities/senses/Health.spec.js
+++ b/test/abilities/senses/Health.spec.js
@@ -4,8 +4,8 @@ import Warrior from '../../../src/units/Warrior';
 describe('Health', () => {
   it('should return the amount of health', () => {
     const warrior = new Warrior();
-    const health = new Health(warrior);
     warrior.health = 10;
+    const health = new Health(warrior);
     expect(health.perform()).toBe(10);
   });
 });

--- a/test/units/Unit.spec.js
+++ b/test/units/Unit.spec.js
@@ -1,11 +1,16 @@
+import Position from '../../src/Position';
 import Unit from '../../src/units/Unit';
 
 describe('Unit', () => {
   let unit;
 
   beforeEach(() => {
-    unit = new Unit();
-    unit.position = {};
+    unit = new Unit(0);
+    unit.position = new Position(null, 0, 0, 'north');
+  });
+
+  it('should have an index property set by the constructor', () => {
+    expect(unit.index).toBe(0);
   });
 
   it('should have a max health which defaults to zero', () => {
@@ -37,7 +42,6 @@ describe('Unit', () => {
   describe('when taking damage', () => {
     beforeEach(() => {
       unit.maxHealth = 10;
-      unit.health = 10;
     });
 
     it('should subtract health', () => {
@@ -153,5 +157,21 @@ describe('Unit', () => {
     expect(() => {
       unit.performTurn();
     }).not.toThrow();
+  });
+
+  describe('view object', () => {
+    it('should have only view object properties', () => {
+      expect(unit.toViewObject()).toEqual({
+        index: 0,
+        name: 'Unit',
+        type: 'unit',
+        position: {
+          x: 0,
+          y: 0,
+          direction: 'north',
+        },
+        health: 0,
+      });
+    });
   });
 });

--- a/test/units/Unit.spec.js
+++ b/test/units/Unit.spec.js
@@ -1,6 +1,10 @@
 import Position from '../../src/Position';
 import Unit from '../../src/units/Unit';
 
+jest.mock('../../src/Logger', () => ({
+  unit: () => {},
+}));
+
 describe('Unit', () => {
   let unit;
 

--- a/test/units/Warrior.spec.js
+++ b/test/units/Warrior.spec.js
@@ -1,5 +1,9 @@
 import Warrior from '../../src/units/Warrior';
 
+jest.mock('../../src/Logger', () => ({
+  unit: () => {},
+}));
+
 describe('Warrior', () => {
   const warrior = new Warrior();
 


### PR DESCRIPTION
The logger was simplified to only log unit changes (and not the entire floor) each time the unit is affected by an action. This is possible because an identifier (the index in the units array of the floor) was added to each unit so that the changes to the unit can be applied to the original floor.

An event for the warrior walking forward may look like this:

```javascript
{
  unit: {
    index: 0,
    name: 'Spartacus',
    type: 'warrior',
    position: {
      x: 0,
      y: 1,
      direction: 'east',
    },
    health: 20,
  },
  message: 'walks forward',
}
```